### PR TITLE
Rename Label file to fix build failure

### DIFF
--- a/Example/Example/Assets.swift
+++ b/Example/Example/Assets.swift
@@ -1,5 +1,5 @@
 //
-//  Label.swift
+//  Assets.swift
 //  Example
 //
 //  Created by tarunon on 2020/01/05.


### PR DESCRIPTION
Renames `Label.swift` -> `Assets.swift`

---
In https://github.com/tarunon/UIViewBuilder/commit/ab26057bfb9c9c499626ce92371e223c49f015ed, `Label.swift` was renamed to `Assets.swift` in the project, but the file itself wasn't renamed causing the Example project to stop compiling.